### PR TITLE
fixing teleop bug with select command

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -274,11 +274,12 @@ public class RobotContainer {
         driverRightTrigger.whileTrue(new SelectCommand<ScoringState>(Map.of(
                 ScoringState.SPEAKER,
                 new IndexerCommand(indexerSubsystem, shooterSubsystem, ShooterConstants.kShooterRPM - 200),
-                ScoringState.AMP,
-                new AmpScoreCommand(pivotAngleSubsystem, shooterSubsystem, indexerSubsystem),
+                // ScoringState.AMP,
+                // new AmpScoreCommand(pivotAngleSubsystem, shooterSubsystem, indexerSubsystem),
                 ScoringState.ManualShoot,
                 new IndexerCommand(indexerSubsystem, shooterSubsystem, ShooterConstants.kShooterRPM - 200)),
                 () -> scoringState));
+        driverRightBumper.whileTrue(new AmpScoreCommand(pivotAngleSubsystem, shooterSubsystem, indexerSubsystem));
     }
 
     public Command getAutonomousCommand() {


### PR DESCRIPTION
We had to move Amp scoring to right bumper to avoid bug where right trigger would cancel left trigger commands.