### PR TITLE
Shooter adjustments

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -235,7 +235,7 @@ public final class Constants {
         public static final double kTrapShooterRPM = 800;
         public static final double kSubwooferShooterRPM = 2750;
         public static final double kPodiumShooterRPM = 4000;
-        public static final double kShuttleShootRPM = 1000;
+        public static final double kShuttleShootRPM = 2000;
     }
 
     public static final class IndexerConstants {

--- a/src/main/java/frc/robot/commands/PreSpinShooter.java
+++ b/src/main/java/frc/robot/commands/PreSpinShooter.java
@@ -34,7 +34,9 @@ public class PreSpinShooter extends Command {
     // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
-        if (indexer.hasNote() && scoringState.get() == ScoringState.HIGH) {
+        if (indexer.hasNote()
+                && (scoringState.get() == ScoringState.HIGH || scoringState.get() == ScoringState.PodiumShoot
+                        || scoringState.get() == ScoringState.SubwooferShoot)) {
             shooter.shooterPID(ShooterConstants.kShooterRPM * 0.7);
         } else {
             shooter.shooterSpeedControl(0, 0, 0);


### PR DESCRIPTION
This branch has 2 main changes.

1. Increase shuttle RPM from 1000RPM to 2000RPM.
2. Enable pre-spin for podium and subwoofer shots. Before it was only high shot. Will not pre spin shooter in LOW or CLIMB states. 

Code has not been tested on robot, but has minimal impact. Defer to reviewers if we want to merge or wait for testing. 